### PR TITLE
feat: add WiX installer skeleton

### DIFF
--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Name="AplicacionPyme" Version="1.0.0" Manufacturer="TuEmpresa" Language="1033" UpgradeCode="e18e4adb-79b7-43da-9c0b-d68fadbd7a96">
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate />
+
+    <Property Id="DB_USER" Value="app_user" />
+    <Property Id="DB_PASSWORD" Value="change_me" />
+    <Property Id="DB_CONNECT_STRING" Value="localhost:1521/XEPDB1" />
+    <Property Id="API_PORT" Value="4000" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLDIR" Name="AplicacionPyme">
+          <Directory Id="LOGSDIR" Name="logs" />
+        </Directory>
+      </Directory>
+      <Directory Id="CommonAppDataFolder">
+        <Directory Id="APPDATADIR" Name="AplicacionPyme">
+          <Directory Id="CONFIGDIR" Name="config" />
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id="Desktop" Title="Desktop" Level="1" />
+    <Feature Id="ApiService" Title="ApiService" Level="1" />
+    <Feature Id="OracleClient" Title="OracleClient" Level="1" />
+
+    <UIRef Id="WixUI_InstallDir" />
+  </Product>
+</Wix>

--- a/installer/wix/README-WiX.md
+++ b/installer/wix/README-WiX.md
@@ -1,0 +1,34 @@
+# Instalador WiX para AplicacionPyme
+
+Este directorio contiene un esqueleto de proyecto [WiX Toolset](https://wixtoolset.org/) para generar un MSI básico de **AplicacionPyme**.
+
+## Requisitos
+- [WiX Toolset 3.x](https://wixtoolset.org/releases/)
+- Windows con las herramientas `candle.exe` y `light.exe` en el `PATH`.
+
+## Compilación
+1. Abrir una consola de comandos de Windows.
+2. Navegar a este directorio: `installer\wix`.
+3. Ejecutar:
+   ```bat
+   build_msi.bat
+   ```
+   Se generará el archivo `AplicacionPyme.msi`.
+
+## Propiedades de base de datos y API
+El MSI expone las siguientes propiedades con valores por defecto:
+
+| Propiedad | Valor por defecto |
+|-----------|------------------|
+| `DB_USER` | `app_user` |
+| `DB_PASSWORD` | `change_me` |
+| `DB_CONNECT_STRING` | `localhost:1521/XEPDB1` |
+| `API_PORT` | `4000` |
+
+Puede sobreescribirlas al momento de instalar:
+
+```powershell
+msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" API_PORT=8080
+```
+
+La interfaz `WixUI_InstallDir` permite elegir la carpeta de instalación mediante la opción `INSTALLDIR`.

--- a/installer/wix/build_msi.bat
+++ b/installer/wix/build_msi.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+candle Product.wxs -ext WixUIExtension -o Product.wixobj
+light Product.wixobj -ext WixUIExtension -o AplicacionPyme.msi
+
+endlocal


### PR DESCRIPTION
## Summary
- add minimal WiX `Product.wxs` defining directories, features, default DB properties, and basic UI
- provide `build_msi.bat` script to compile MSI using WiX Toolset
- document build steps and property overrides in `README-WiX.md`

## Testing
- `bash installer/wix/build_msi.bat` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b7c16cac8322840b7d505a1bc262