### PR TITLE
Add WiX custom actions for NSSM-based API service

### DIFF
--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -35,6 +35,21 @@
       <ComponentGroupRef Id="CG.OracleClient" />
     </Feature>
 
+    <InstallExecuteSequence>
+      <!-- Verify that service files exist before installing -->
+      <Custom Action="CA.VerifyServiceFiles" After="InstallFiles">NOT Installed AND &ApiService=3</Custom>
+      <!-- Install and configure service -->
+      <Custom Action="CA.InstallService" After="CA.VerifyServiceFiles">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="CA.SetServiceDirectory" After="CA.InstallService">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="CA.SetServiceLogs" After="CA.SetServiceDirectory">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="CA.SetServiceEnv" After="CA.SetServiceLogs">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="CA.StartService" After="CA.SetServiceEnv">NOT Installed AND &ApiService=3</Custom>
+
+      <!-- Stop and remove service on uninstall -->
+      <Custom Action="CA.StopService" Before="CA.RemoveService">REMOVE="ALL" AND ?ApiService=3</Custom>
+      <Custom Action="CA.RemoveService" Before="RemoveFiles">REMOVE="ALL" AND ?ApiService=3</Custom>
+    </InstallExecuteSequence>
+
     <UIRef Id="WixUI_InstallDir" />
   </Product>
 </Wix>

--- a/installer/wix/README-WiX.md
+++ b/installer/wix/README-WiX.md
@@ -46,3 +46,24 @@ msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" API_P
 ```
 
 La interfaz `WixUI_InstallDir` permite elegir la carpeta de instalación mediante la opción `INSTALLDIR`.
+
+## Servicio Windows de la API
+La instalación registra la API como un servicio de Windows llamado `AplicacionPymeAPI` utilizando `nssm.exe`. El servicio se inicia automáticamente al final de la instalación y se elimina al desinstalar el MSI.
+
+### Verificación
+Para comprobar el estado del servicio:
+
+```powershell
+sc query AplicacionPymeAPI
+```
+
+Los logs del servicio se escriben en `INSTALLDIR\logs` y se rotan automáticamente.
+
+Si `node\node.exe` o `server\dist\app.js` no están presentes durante la instalación, el MSI mostrará un error claro indicando el archivo faltante.
+
+### Propiedades de entorno
+Las propiedades `DB_USER`, `DB_PASSWORD`, `DB_CONNECT_STRING` y `API_PORT` se pasan al servicio como variables de entorno junto con `APP_CONFIG_DIR`, que apunta a la carpeta `CONFIGDIR`. Puede sobreescribirlas usando `msiexec` como se mostró anteriormente:
+
+```powershell
+msiexec /i AplicacionPyme.msi DB_USER=usuario DB_PASSWORD=clave DB_CONNECT_STRING="servidor:puerto/servicio" API_PORT=8080
+```

--- a/installer/wix/ServiceActions.wxs
+++ b/installer/wix/ServiceActions.wxs
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <!-- Verify required files exist -->
+    <util:WixQuietExec Id="CA.VerifyServiceFiles"
+      Command='cmd /c if exist "[INSTALLDIR]node\\node.exe" (if exist "[INSTALLDIR]server\\dist\\app.js" (exit 0) else (echo Missing server\\dist\\app.js && exit 1)) else (echo Missing node\\node.exe && exit 1)'
+      Execute="immediate" Return="check"/>
+
+    <!-- Install service using nssm -->
+    <util:WixQuietExec Id="CA.InstallService"
+      Command='"[INSTALLDIR]nssm.exe" install AplicacionPymeAPI "[INSTALLDIR]node\\node.exe" "[INSTALLDIR]server\\dist\\app.js"'
+      Execute="deferred" Impersonate="no" Return="check"/>
+
+    <!-- Configure directory and logs -->
+    <util:WixQuietExec Id="CA.SetServiceDirectory"
+      Command='"[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppDirectory "[INSTALLDIR]"'
+      Execute="deferred" Impersonate="no" Return="check"/>
+
+    <util:WixQuietExec Id="CA.SetServiceLogs"
+      Command='cmd /c ""[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppStdout "[LOGSDIR]api.log" && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppStderr "[LOGSDIR]api-error.log" && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppRotateFiles 1"'
+      Execute="deferred" Impersonate="no" Return="check"/>
+
+    <!-- Configure environment variables -->
+    <util:WixQuietExec Id="CA.SetServiceEnv"
+      Command='"[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppEnvironmentExtra "DB_USER=[DB_USER]\r\nDB_PASSWORD=[DB_PASSWORD]\r\nDB_CONNECT_STRING=[DB_CONNECT_STRING]\r\nAPI_PORT=[API_PORT]\r\nAPP_CONFIG_DIR=[CONFIGDIR]"'
+      Execute="deferred" Impersonate="no" Return="check"/>
+
+    <!-- Start service -->
+    <util:WixQuietExec Id="CA.StartService"
+      Command='"[INSTALLDIR]nssm.exe" start AplicacionPymeAPI'
+      Execute="deferred" Impersonate="no" Return="check"/>
+
+    <!-- Stop and remove service for uninstall -->
+    <util:WixQuietExec Id="CA.StopService"
+      Command='"[INSTALLDIR]nssm.exe" stop AplicacionPymeAPI'
+      Execute="deferred" Impersonate="no" Return="ignore"/>
+
+    <util:WixQuietExec Id="CA.RemoveService"
+      Command='"[INSTALLDIR]nssm.exe" remove AplicacionPymeAPI confirm'
+      Execute="deferred" Impersonate="no" Return="ignore"/>
+  </Fragment>
+</Wix>

--- a/installer/wix/build_msi.bat
+++ b/installer/wix/build_msi.bat
@@ -1,16 +1,16 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set WXS_FILES=Product.wxs Files.wxs
+set WXS_FILES=Product.wxs Files.wxs ServiceActions.wxs
 for %%F in (files_*.wxs) do (
   if exist "%%F" set WXS_FILES=!WXS_FILES! %%F
 )
 
-candle !WXS_FILES! -ext WixUIExtension
+candle !WXS_FILES! -ext WixUIExtension -ext WixUtilExtension
 
 set WIXOBJS=
 for %%F in (!WXS_FILES!) do set WIXOBJS=!WIXOBJS! %%~nF.wixobj
 
-light !WIXOBJS! -ext WixUIExtension -o AplicacionPyme.msi
+light !WIXOBJS! -ext WixUIExtension -ext WixUtilExtension -o AplicacionPyme.msi
 
 endlocal


### PR DESCRIPTION
## Summary
- add ServiceActions.wxs with WixQuietExec steps to install, configure and manage the API Windows service through nssm
- sequence service actions in Product.wxs and gate them on the ApiService feature
- compile with WixUtilExtension and document service usage

## Testing
- `bash build_msi.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c0f75f74832296ac435cb9e855ec