### PR TITLE
feat(installer): register API as Windows service with NSSM

### DIFF
--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -35,6 +35,7 @@
       <ComponentGroupRef Id="CG.OracleClient" />
     </Feature>
 
+    <FragmentRef Id="ServiceActions" />
     <UIRef Id="WixUI_InstallDir" />
   </Product>
 </Wix>

--- a/installer/wix/README-WiX.md
+++ b/installer/wix/README-WiX.md
@@ -46,3 +46,21 @@ msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" API_P
 ```
 
 La interfaz `WixUI_InstallDir` permite elegir la carpeta de instalación mediante la opción `INSTALLDIR`.
+
+## Servicio Windows
+
+Si durante la instalación se selecciona la característica **ApiService**, el MSI registra un servicio de Windows llamado `AplicacionPymeAPI` utilizando [NSSM](https://nssm.cc/). El servicio se inicia automáticamente y guarda los logs en `INSTALLDIR\logs`.
+
+Para comprobar su estado:
+
+```powershell
+sc query AplicacionPymeAPI
+```
+
+Las propiedades `DB_USER`, `DB_PASSWORD`, `DB_CONNECT_STRING` y `API_PORT` se pasan como variables de entorno al servicio junto con `APP_CONFIG_DIR` apuntando a `CONFIGDIR`. Puede sobreescribirlas al instalar:
+
+```powershell
+msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" DB_CONNECT_STRING="servidor:1521/XEPDB1" API_PORT=8080
+```
+
+Si `node\node.exe` o `server\dist\app.js` faltan en `INSTALLDIR`, la instalación mostrará un error al crear el servicio.

--- a/installer/wix/ServiceActions.wxs
+++ b/installer/wix/ServiceActions.wxs
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment Id="ServiceActions">
+    <CustomAction Id="InstallApiService"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" install AplicacionPymeAPI "[INSTALLDIR]node\node.exe" "[INSTALLDIR]server\dist\app.js"'/>
+    </CustomAction>
+
+    <CustomAction Id="ConfigureApiService"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppDirectory "[INSTALLDIR]" && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppStdout "[LOGSDIR]api.log" && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppStderr "[LOGSDIR]api.err.log" && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppRotateFiles 1 && "[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppRotateBytes 10485760'/>
+    </CustomAction>
+
+    <CustomAction Id="SetApiServiceEnv"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" set AplicacionPymeAPI AppEnvironmentExtra "DB_USER=[DB_USER];DB_PASSWORD=[DB_PASSWORD];DB_CONNECT_STRING=[DB_CONNECT_STRING];API_PORT=[API_PORT];APP_CONFIG_DIR=[CONFIGDIR]"'/>
+    </CustomAction>
+
+    <CustomAction Id="StartApiService"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" start AplicacionPymeAPI'/>
+    </CustomAction>
+
+    <CustomAction Id="StopApiService"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" stop AplicacionPymeAPI'/>
+    </CustomAction>
+
+    <CustomAction Id="RemoveApiService"
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check">
+      <util:WixQuietExec Command='"[INSTALLDIR]nssm.exe" remove AplicacionPymeAPI confirm'/>
+    </CustomAction>
+
+    <InstallExecuteSequence>
+      <Custom Action="InstallApiService" After="InstallFiles">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="ConfigureApiService" After="InstallApiService">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="SetApiServiceEnv" After="ConfigureApiService">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="StartApiService" After="SetApiServiceEnv">NOT Installed AND &ApiService=3</Custom>
+      <Custom Action="StopApiService" Before="RemoveFiles">REMOVE="ALL" AND ?ApiService=3</Custom>
+      <Custom Action="RemoveApiService" After="StopApiService">REMOVE="ALL" AND ?ApiService=3</Custom>
+    </InstallExecuteSequence>
+  </Fragment>
+</Wix>

--- a/installer/wix/build_msi.bat
+++ b/installer/wix/build_msi.bat
@@ -1,16 +1,16 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set WXS_FILES=Product.wxs Files.wxs
+set WXS_FILES=Product.wxs Files.wxs ServiceActions.wxs
 for %%F in (files_*.wxs) do (
   if exist "%%F" set WXS_FILES=!WXS_FILES! %%F
 )
 
-candle !WXS_FILES! -ext WixUIExtension
+candle !WXS_FILES! -ext WixUIExtension -ext WixUtilExtension
 
 set WIXOBJS=
 for %%F in (!WXS_FILES!) do set WIXOBJS=!WIXOBJS! %%~nF.wixobj
 
-light !WIXOBJS! -ext WixUIExtension -o AplicacionPyme.msi
+light !WIXOBJS! -ext WixUIExtension -ext WixUtilExtension -o AplicacionPyme.msi
 
 endlocal


### PR DESCRIPTION
## Summary
- add ServiceActions.wxs with custom actions to install and manage the API service via NSSM
- integrate WiX Util extension and new fragment into build script and product definition
- document how to verify and configure the Windows service in README

## Testing
- `./build_msi.bat` *(fails: Permission denied)*
- `bash build_msi.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c0f75f74832296ac435cb9e855ec