### PR TITLE
feat(installer): include config templates

### DIFF
--- a/config_templates/app.properties.example
+++ b/config_templates/app.properties.example
@@ -1,0 +1,7 @@
+# JDBC URL, por ejemplo para Oracle XE
+APP_DB_URL=jdbc:oracle:thin:@//localhost:1521/XEPDB1
+APP_DB_USER=app_user
+APP_DB_PASSWORD=change_me
+
+# Otros
+APP_LOG_LEVEL=INFO

--- a/config_templates/server.env.example
+++ b/config_templates/server.env.example
@@ -1,0 +1,5 @@
+API_PORT=4000
+DB_USER=app_user
+DB_PASSWORD=change_me
+DB_CONNECT_STRING=localhost:1521/XEPDB1
+# DB_URL=localhost:1521/XEPDB1

--- a/installer/wix/ConfigFiles.wxs
+++ b/installer/wix/ConfigFiles.wxs
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <DirectoryRef Id="CONFIGDIR">
+      <Component Id="Cmp.AppProperties" Guid="*">
+        <File Id="Fil.app.properties" Source="$(var.SourceDir)\\config_templates\\app.properties.example" Name="app.properties"  KeyPath="yes" NeverOverwrite="yes" />
+      </Component>
+      <Component Id="Cmp.Env" Guid="*">
+        <File Id="Fil.env" Source="$(var.SourceDir)\\config_templates\\server.env.example" Name=".env" KeyPath="yes" NeverOverwrite="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="CG.Config">
+      <ComponentRef Id="Cmp.AppProperties" />
+      <ComponentRef Id="Cmp.Env" />
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -30,6 +30,7 @@
     </Feature>
     <Feature Id="ApiService" Title="ApiService" Level="1">
       <ComponentGroupRef Id="CG.Api" />
+      <ComponentGroupRef Id="CG.Config" />
     </Feature>
     <Feature Id="OracleClient" Title="OracleClient" Level="1">
       <ComponentGroupRef Id="CG.OracleClient" />

--- a/installer/wix/README-WiX.md
+++ b/installer/wix/README-WiX.md
@@ -47,6 +47,14 @@ msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" API_P
 
 La interfaz `WixUI_InstallDir` permite elegir la carpeta de instalación mediante la opción `INSTALLDIR`.
 
+## Archivos de configuración en ProgramData
+Durante la instalación se copian dos archivos de ejemplo en `C:\ProgramData\AplicacionPyme\config\`:
+
+- `app.properties`: parámetros de la aplicación de escritorio.
+- `.env`: variables para el servicio de la API.
+
+Los archivos provienen del directorio `config_templates` y se instalan con `NeverOverwrite="yes"`, por lo que las modificaciones del usuario se conservarán en reinstalaciones o upgrades.
+
 ## Servicio Windows de la API
 La instalación registra la API como un servicio de Windows llamado `AplicacionPymeAPI` utilizando `nssm.exe`. El servicio se inicia automáticamente al final de la instalación y se elimina al desinstalar el MSI.
 


### PR DESCRIPTION
## Summary
- add WiX fragment to install app.properties and .env templates in ProgramData without overwriting on upgrades
- reference new config component group from ApiService feature
- document configurable templates in README

## Testing
- `bash build_msi.bat` *(fails: command not found / Windows script not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d00a20f083229a013c012b85963d