### PR TITLE
Add desktop shortcuts and logs directory

### DIFF
--- a/installer/wix/Files.wxs
+++ b/installer/wix/Files.wxs
@@ -10,6 +10,16 @@
   </Fragment>
 
   <Fragment>
+    <DirectoryRef Id="LOGSDIR">
+      <Component Id="Cmp.LogsFolder" Guid="*">
+        <CreateFolder />
+        <RemoveFolder Id="RemoveLogsFolder" On="uninstall" />
+        <RegistryValue Root="HKCU" Key="Software\\AplicacionPyme" Name="logsfolder" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
     <ComponentGroup Id="CG.Api">
       <ComponentRef Id="Cmp.NssmExe" />
       <!-- Components harvested into CG.Api will be referenced here -->
@@ -19,6 +29,12 @@
   <Fragment>
     <ComponentGroup Id="CG.Desktop">
       <!-- Components harvested into CG.Desktop will be referenced here -->
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="CG.Logs">
+      <ComponentRef Id="Cmp.LogsFolder" />
     </ComponentGroup>
   </Fragment>
 

--- a/installer/wix/Product.wxs
+++ b/installer/wix/Product.wxs
@@ -23,13 +23,18 @@
           <Directory Id="CONFIGDIR" Name="config" />
         </Directory>
       </Directory>
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="ProgramMenuDir" Name="AplicacionPyme" />
+      </Directory>
     </Directory>
 
     <Feature Id="Desktop" Title="Desktop" Level="1">
       <ComponentGroupRef Id="CG.Desktop" />
+      <ComponentGroupRef Id="CG.Shortcuts" />
     </Feature>
     <Feature Id="ApiService" Title="ApiService" Level="1">
       <ComponentGroupRef Id="CG.Api" />
+      <ComponentGroupRef Id="CG.Logs" />
     </Feature>
     <Feature Id="OracleClient" Title="OracleClient" Level="1">
       <ComponentGroupRef Id="CG.OracleClient" />

--- a/installer/wix/README-WiX.md
+++ b/installer/wix/README-WiX.md
@@ -45,6 +45,12 @@ Puede sobreescribirlas al momento de instalar:
 msiexec /i AplicacionPyme.msi DB_USER="otro_usuario" DB_PASSWORD="secreto" API_PORT=8080
 ```
 
+Para instalaciones silenciosas se puede agregar `/qn` al comando:
+
+```powershell
+msiexec /i AplicacionPyme.msi DB_USER=usuario DB_PASSWORD=clave API_PORT=8080 /qn
+```
+
 La interfaz `WixUI_InstallDir` permite elegir la carpeta de instalación mediante la opción `INSTALLDIR`.
 
 ## Servicio Windows de la API
@@ -67,3 +73,11 @@ Las propiedades `DB_USER`, `DB_PASSWORD`, `DB_CONNECT_STRING` y `API_PORT` se pa
 ```powershell
 msiexec /i AplicacionPyme.msi DB_USER=usuario DB_PASSWORD=clave DB_CONNECT_STRING="servidor:puerto/servicio" API_PORT=8080
 ```
+
+## Pruebas
+
+1. Instalar el MSI pasando las propiedades necesarias.
+2. Verificar que el servicio `AplicacionPymeAPI` esté en ejecución.
+3. Confirmar que se creó `INSTALLDIR\\logs` y la carpeta `ProgramData\\AplicacionPyme` con los archivos de configuración.
+4. Si se incluye la aplicación de escritorio, comprobar los accesos directos en el menú Inicio y el escritorio.
+5. Desinstalar y validar que el servicio y los archivos en `ProgramFiles` y `ProgramData` se eliminaron.

--- a/installer/wix/Shortcuts.wxs
+++ b/installer/wix/Shortcuts.wxs
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <util:FileSearch Id="DesktopExeSearch" Path="[INSTALLDIR]desktop" Pattern="AplicacionPyme.exe" Variable="DESKTOPEXE" />
+
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="Cmp.DesktopShortcuts" Guid="*">
+        <Condition>DESKTOPEXE</Condition>
+        <RegistryValue Root="HKCU" Key="Software\\AplicacionPyme" Name="desktop" Type="integer" Value="1" KeyPath="yes"/>
+        <Shortcut Id="StartMenuShortcut" Name="AplicacionPyme" Directory="ProgramMenuDir" Target="[DESKTOPEXE]" WorkingDirectory="INSTALLDIR"/>
+        <Shortcut Id="DesktopShortcut" Name="AplicacionPyme" Directory="DesktopFolder" Target="[DESKTOPEXE]" WorkingDirectory="INSTALLDIR"/>
+        <RemoveFolder Id="RemoveProgramMenuDir" Directory="ProgramMenuDir" On="uninstall"/>
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="CG.Shortcuts">
+      <ComponentRef Id="Cmp.DesktopShortcuts"/>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/installer/wix/build_msi.bat
+++ b/installer/wix/build_msi.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set WXS_FILES=Product.wxs Files.wxs ServiceActions.wxs
+set WXS_FILES=Product.wxs Files.wxs Shortcuts.wxs ServiceActions.wxs
 for %%F in (files_*.wxs) do (
   if exist "%%F" set WXS_FILES=!WXS_FILES! %%F
 )


### PR DESCRIPTION
## Summary
- add conditional desktop and start menu shortcuts
- include logs directory and component group
- document msiexec properties, silent install, and test steps

## Testing
- `bash build_msi.bat` *(fails: command not found, requires Windows tools)*

------
https://chatgpt.com/codex/tasks/task_e_68a80b7cb8fc832288c73e538563b70d